### PR TITLE
Fix for window forcing itself into the foreground.

### DIFF
--- a/ping_graph.py
+++ b/ping_graph.py
@@ -290,8 +290,6 @@ if __name__ == "__main__":
             update_stats(ax, times_snapshot, timeout, dead_timeout, start_time,
                          n_scheduled=n_scheduled, n_inflight=inflight_count)
 
-
-            fig.canvas.draw_idle()
             fig.canvas.start_event_loop(0.2)
     except KeyboardInterrupt:
         stop_event.set()

--- a/ping_graph.py
+++ b/ping_graph.py
@@ -290,6 +290,7 @@ if __name__ == "__main__":
             update_stats(ax, times_snapshot, timeout, dead_timeout, start_time,
                          n_scheduled=n_scheduled, n_inflight=inflight_count)
 
+
             fig.canvas.start_event_loop(0.2)
     except KeyboardInterrupt:
         stop_event.set()

--- a/ping_graph.py
+++ b/ping_graph.py
@@ -291,7 +291,8 @@ if __name__ == "__main__":
                          n_scheduled=n_scheduled, n_inflight=inflight_count)
 
 
-            plt.pause(0.2)
+            fig.canvas.draw_idle()
+            fig.canvas.start_event_loop(0.2)
     except KeyboardInterrupt:
         stop_event.set()
         plt.close(fig)


### PR DESCRIPTION
https://github.com/user-attachments/assets/eff35b33-50d0-4437-a12b-9f2f47f8f25a

On my Linux system (Gnome/Wayland) the window would force itself over other windows every time `plt.pause()` was called.
Replacing `plt.pause` with `fig.canvas.start_event_loop` fixed that problem on my system.
I tested it with the Qt5Agg, GTK3Agg, GTK4Agg,  and TkAgg backends without any problems.

I couldn't test it with Windows/MacOS because I only have Linux systems at hand.

(Sorry but but I had to repeat the merge request after deleting my repository 😖)
